### PR TITLE
Symlink new files and track them through the config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,142 @@ version = 3
 [[package]]
 name = "dot"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "indexmap"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "winnow"
+version = "0.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,6 @@ version = 3
 name = "dot"
 version = "0.1.0"
 dependencies = [
- "serde",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.196", features = ["std", "derive"] }
 toml = "0.8.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0.196", features = ["std", "derive"] }
+toml = "0.8.10"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # dot
 
-A simlpe program that manages your dotfiles.
-No extra features, not bloath.
-It takes care of your dotfiles, that's it.
+A simple configuration files (i.e. dotfiles) manager.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,18 +1,17 @@
 use std::{io, path::PathBuf};
 
-use crate::{config, files};
+use crate::{config, error, files};
 
 pub fn add(file_path: &str) -> io::Result<()> {
     let original_file_path = PathBuf::from(file_path);
     let destination_file_path = PathBuf::from(
         original_file_path
             .file_name()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "File name not found"))?,
+            .ok_or_else(error::not_found)?,
     );
 
     let config_path = PathBuf::from(config::CONFIG_FILE_NAME);
-    let config = config::load(&files::read(&config_path)?)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let config = config::load(&files::read(&config_path)?).map_err(error::from_other)?;
 
     if config::has(&config, &destination_file_path) {
         println!("File already being tracked");
@@ -23,8 +22,7 @@ pub fn add(file_path: &str) -> io::Result<()> {
     let link = files::symlink(&destination_file_path, &original_file_path)?;
 
     let config = config::insert(&config, link.from, link.to);
-    let config_buffer =
-        config::save(&config).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let config_buffer = config::save(&config).map_err(error::from_other)?;
 
     files::write(&config_path, &config_buffer)?;
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,7 +10,11 @@ pub fn add(file_path: &str) -> io::Result<()> {
     let config_path = PathBuf::from(config::CONFIG_FILE_NAME);
     let config = config::load(&files::read(&config_path)?).unwrap(); // TODO: remove unwrap
 
-    // TODO: make sure the file is not already in the config and being tracked
+    if config::has(&config, &destination_file_path.to_str().unwrap()) {
+        // TODO: remove unwrap above
+        println!("File already being tracked");
+        return Ok(());
+    }
 
     files::rename(&original_file_path, &destination_file_path)?;
     let link = files::symlink(&destination_file_path, &original_file_path)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,4 @@
-use std::{
-    io,
-    path::{Path, PathBuf},
-};
+use std::{io, path::PathBuf};
 
 use crate::{config, files};
 
@@ -21,7 +18,7 @@ pub fn add(file_path: &str) -> io::Result<()> {
     let config = config::insert(
         &config,
         link.from.to_str().unwrap().to_owned(), // TODO: remove unwrap
-        link.to.to_str().unwrap().to_owned(),   // TODO: remove unwrap
+        link.to.to_str().unwrap().to_owned(),   // TODO: remove unwrap, also add full aboslute path
     );
 
     let config_buffer = config::save(&config).unwrap(); // TODO: remove unwrap

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,31 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use crate::{config, files};
+
+pub fn add(file_path: &str) -> io::Result<()> {
+    let original_file_path = PathBuf::from(file_path);
+    let file_name = original_file_path.file_name().unwrap(); // TODO: remove unwrap
+    let destination_file_path = PathBuf::from(file_name);
+
+    let config_path = PathBuf::from(config::CONFIG_FILE_NAME);
+    let config = config::load(&files::read(&config_path)?).unwrap(); // TODO: remove unwrap
+
+    // TODO: make sure the file is not already in the config and being tracked
+
+    files::rename(&original_file_path, &destination_file_path)?;
+    let link = files::symlink(&destination_file_path, &original_file_path)?;
+
+    let config = config::insert(
+        &config,
+        link.from.to_str().unwrap().to_owned(), // TODO: remove unwrap
+        link.to.to_str().unwrap().to_owned(),   // TODO: remove unwrap
+    );
+
+    let config_buffer = config::save(&config).unwrap(); // TODO: remove unwrap
+    files::write(&config_path, &config_buffer)?;
+
+    Ok(())
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,11 +4,11 @@ use crate::{config, files};
 
 pub fn add(file_path: &str) -> io::Result<()> {
     let original_file_path = PathBuf::from(file_path);
-    let file_name = original_file_path
-        .file_name()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "File name not found"))?;
-
-    let destination_file_path = PathBuf::from(file_name);
+    let destination_file_path = PathBuf::from(
+        original_file_path
+            .file_name()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "File name not found"))?,
+    );
 
     let config_path = PathBuf::from(config::CONFIG_FILE_NAME);
     let config = config::load(&files::read(&config_path)?)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,14 +4,22 @@ use crate::{config, files};
 
 pub fn add(file_path: &str) -> io::Result<()> {
     let original_file_path = PathBuf::from(file_path);
-    let file_name = original_file_path.file_name().unwrap(); // TODO: remove unwrap
+    let file_name = original_file_path
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "File name not found"))?;
+
     let destination_file_path = PathBuf::from(file_name);
 
     let config_path = PathBuf::from(config::CONFIG_FILE_NAME);
-    let config = config::load(&files::read(&config_path)?).unwrap(); // TODO: remove unwrap
+    let config = config::load(&files::read(&config_path)?)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-    if config::has(&config, &destination_file_path.to_str().unwrap()) {
-        // TODO: remove unwrap above
+    if config::has(
+        &config,
+        file_name.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "File name is not valid UTF-8")
+        })?,
+    ) {
         println!("File already being tracked");
         return Ok(());
     }
@@ -25,7 +33,9 @@ pub fn add(file_path: &str) -> io::Result<()> {
         link.to.to_str().unwrap().to_owned(),   // TODO: remove unwrap, also add full aboslute path
     );
 
-    let config_buffer = config::save(&config).unwrap(); // TODO: remove unwrap
+    let config_buffer =
+        config::save(&config).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
     files::write(&config_path, &config_buffer)?;
 
     Ok(())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,12 +14,7 @@ pub fn add(file_path: &str) -> io::Result<()> {
     let config = config::load(&files::read(&config_path)?)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-    if config::has(
-        &config,
-        file_name.to_str().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "File name is not valid UTF-8")
-        })?,
-    ) {
+    if config::has(&config, &destination_file_path) {
         println!("File already being tracked");
         return Ok(());
     }
@@ -27,12 +22,7 @@ pub fn add(file_path: &str) -> io::Result<()> {
     files::rename(&original_file_path, &destination_file_path)?;
     let link = files::symlink(&destination_file_path, &original_file_path)?;
 
-    let config = config::insert(
-        &config,
-        link.from.to_str().unwrap().to_owned(), // TODO: remove unwrap
-        link.to.to_str().unwrap().to_owned(),   // TODO: remove unwrap, also add full aboslute path
-    );
-
+    let config = config::insert(&config, link.from, link.to);
     let config_buffer =
         config::save(&config).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,19 @@
 use toml::ser::Error;
 
-type Config = toml::Table;
+pub const CONFIG_FILE_NAME: &str = "dot_config.toml";
+
+pub type Config = toml::Table;
 
 pub fn load(buffer: &str) -> Result<Config, Error> {
     toml::Table::try_from(buffer)
 }
 
-fn insert(config: &Config, file: String, link: String) -> Config {
+pub fn save(config: &Config) -> Result<String, Error> {
+    toml::to_string(config)
+}
+
+pub fn insert(config: &Config, file: String, link: String) -> Config {
     let mut updated_config = config.clone();
     updated_config.insert(file, toml::Value::String(link));
     updated_config
-}
-
-pub fn write(config: &Config) -> Result<String, Error> {
-    toml::to_string(config)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::{
 
 use toml::{de, ser};
 
-pub const CONFIG_FILE_NAME: &str = ".dot_config.toml";
+pub const CONFIG_FILE_NAME: &str = "dot_config.toml";
 
 pub type Config = HashMap<PathBuf, PathBuf>;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,17 @@
+use toml::ser::Error;
+
+type Config = toml::Table;
+
+pub fn load(buffer: &str) -> Result<Config, Error> {
+    toml::Table::try_from(buffer)
+}
+
+fn insert(config: &Config, file: String, link: String) -> Config {
+    let mut updated_config = config.clone();
+    updated_config.insert(file, toml::Value::String(link));
+    updated_config
+}
+
+pub fn write(config: &Config) -> Result<String, Error> {
+    toml::to_string(config)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,19 +1,21 @@
-use toml::ser::Error;
+use std::collections::HashMap;
 
-pub const CONFIG_FILE_NAME: &str = "dot_config.toml";
+use toml::{de, ser};
 
-pub type Config = toml::Table;
+pub const CONFIG_FILE_NAME: &str = ".dot_config.toml";
 
-pub fn load(buffer: &str) -> Result<Config, Error> {
-    toml::Table::try_from(buffer)
+pub type Config = HashMap<String, String>;
+
+pub fn load(buffer: &str) -> Result<Config, de::Error> {
+    toml::from_str(buffer)
 }
 
-pub fn save(config: &Config) -> Result<String, Error> {
+pub fn save(config: &Config) -> Result<String, ser::Error> {
     toml::to_string(config)
 }
 
 pub fn insert(config: &Config, file: String, link: String) -> Config {
     let mut updated_config = config.clone();
-    updated_config.insert(file, toml::Value::String(link));
+    updated_config.insert(file, link);
     updated_config
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,13 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use toml::{de, ser};
 
 pub const CONFIG_FILE_NAME: &str = ".dot_config.toml";
 
-pub type Config = HashMap<String, String>;
+pub type Config = HashMap<PathBuf, PathBuf>;
 
 pub fn load(buffer: &str) -> Result<Config, de::Error> {
     toml::from_str(buffer)
@@ -14,12 +17,12 @@ pub fn save(config: &Config) -> Result<String, ser::Error> {
     toml::to_string(config)
 }
 
-pub fn insert(config: &Config, file: String, link: String) -> Config {
+pub fn insert(config: &Config, file: PathBuf, link: PathBuf) -> Config {
     let mut updated_config = config.clone();
     updated_config.insert(file, link);
     updated_config
 }
 
-pub fn has(config: &Config, file: &str) -> bool {
+pub fn has(config: &Config, file: &Path) -> bool {
     config.get(file).is_some()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,3 +19,7 @@ pub fn insert(config: &Config, file: String, link: String) -> Config {
     updated_config.insert(file, link);
     updated_config
 }
+
+pub fn has(config: &Config, file: &str) -> bool {
+    config.get(file).is_some()
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,14 @@
+use std::io;
+
+pub type Error = io::Error;
+
+pub fn not_found() -> Error {
+    io::Error::new(io::ErrorKind::NotFound, "File name not found")
+}
+
+pub fn from_other<E>(e: E) -> Error
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    io::Error::new(io::ErrorKind::Other, e)
+}

--- a/src/files.rs
+++ b/src/files.rs
@@ -17,7 +17,12 @@ impl SymLink {
 }
 
 pub fn symlink(from: &Path, to: &Path) -> io::Result<SymLink> {
-    std::os::unix::fs::symlink(from, to)?;
+    let current_dir = std::env::current_dir()?;
+
+    let from_absolute = current_dir.join(from);
+    let to_absolute = current_dir.join(to);
+
+    std::os::unix::fs::symlink(from_absolute, to_absolute)?;
 
     Ok(SymLink::new(from, to))
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct SymLink {
-    from: PathBuf,
-    to: PathBuf,
+    pub from: PathBuf,
+    pub to: PathBuf,
 }
 
 impl SymLink {
@@ -24,4 +24,12 @@ pub fn symlink(from: &Path, to: &Path) -> io::Result<SymLink> {
 
 pub fn rename(from: &Path, to: &Path) -> io::Result<()> {
     std::fs::rename(from, to)
+}
+
+pub fn read(from: &Path) -> io::Result<String> {
+    std::fs::read_to_string(from)
+}
+
+pub fn write(to: &Path, buffer: &str) -> io::Result<()> {
+    std::fs::write(to, buffer)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+mod config;
 mod files;
 
 fn main() -> std::io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod config;
+mod error;
 mod files;
 
 fn main() -> std::io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,9 @@
-use std::path::Path;
-
 mod commands;
 mod config;
 mod files;
 
 fn main() -> std::io::Result<()> {
-    let from = Path::new("./test.txt");
-    let to = Path::new("./test2.txt");
-
-    files::rename(from, to)?;
-    let link = files::symlink(to, from).unwrap(); // Do not panic!
-
-    println!("{:?}", link);
-
-    println!(
-        "Created Symlink from {} to {}",
-        from.display(),
-        to.display()
-    );
+    commands::add("../test.txt")?;
 
     Ok(()) // TODO: Manage error correctly later
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+mod commands;
 mod config;
 mod files;
 


### PR DESCRIPTION
Introduces the command to add new files to the config, by moving them to the current directory, and then symlinking back to their original location. The added file is also tracked in the dot_config.toml file in order to sync it later on in a different host.