### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2026-02-17
+
+### Features
+
+- Improve logging with custom logger ([#50](https://github.com/leadingperiod/dot/pull/50)) ([422d272](https://github.com/rvillegasm/dot/commit/422d272de8cf0db175e645e77b4537c29982e127))
+
+
 ## [1.1.1] - 2026-02-14
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "dot_rust"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dot_rust"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2024"
 description = "A simple configuration files (i.e. dotfiles) manager."
 categories = ["command-line-utilities"]


### PR DESCRIPTION



## 🤖 New release

* `dot_rust`: 1.1.1 -> 1.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0] - 2026-02-17

### Features

- Improve logging with custom logger ([#50](https://github.com/leadingperiod/dot/pull/50)) ([422d272](https://github.com/rvillegasm/dot/commit/422d272de8cf0db175e645e77b4537c29982e127))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).